### PR TITLE
Fixing search where Title contains spaces

### DIFF
--- a/lib/amazon_product_advertising_client.ex
+++ b/lib/amazon_product_advertising_client.ex
@@ -9,39 +9,41 @@ defmodule AmazonProductAdvertisingClient do
   @path   "/onca/xml"
 
   def call_api(request_params, config \\ %Config{}) do
-    query = [request_params, config] |> combine_params |> URI.encode_query
-    get %URI{scheme: @scheme, host: @host, path: @path, query: query}
+    query = [request_params, config] |> combine |> Map.merge(timestamp) |> parameterize
+    signature = compute_signuature(query)
+
+    get %URI{scheme: @scheme, host: @host, path: @path, query: "#{query}&Signature=#{signature}"}
   end
 
-  defp combine_params(params_list) do
+  defp timestamp do
+    %{"Timestamp" => DateFormat.format!(Date.local, "{ISOz}")}
+  end
+
+  defp combine(params_list) do
     List.foldl params_list, Map.new, fn(params, all_params) ->
       Map.merge Map.from_struct(params), all_params
     end
   end
 
-  def process_url(url) do
-    url |> URI.parse |> timestamp_url |> sign_url |> String.Chars.to_string
+  def parameterize(params) do
+    params |> Enum.map(fn({key, value}) -> "#{key}=#{encode value}" end) |> Enum.sort |> Enum.join("&")
   end
 
-  defp timestamp_url(url_parts) do
-    timestamped_query = url_parts.query
-                        |> URI.decode_query
-                        |> Map.put_new("Timestamp", DateFormat.format!(Date.local, "{ISOz}"))
-                        |> URI.encode_query
-    Map.put url_parts, :query, timestamped_query
+  defp compute_signuature(query) do
+    :crypto.hmac(
+      :sha256,
+      Application.get_env(:amazon_product_advertising_client, :aws_secret_access_key),
+      Enum.join(["GET", @host, @path, query], "\n")
+    )
+    |> Base.encode64
+    |> URI.encode_www_form
   end
 
-  defp sign_url(url_parts) do
-    ordered_query = url_parts.query |> URI.decode_query |> Enum.sort |> URI.encode_query
-    signature =
-      :crypto.hmac(
-        :sha256,
-        Application.get_env(:amazon_product_advertising_client, :aws_secret_access_key),
-        Enum.join(["GET", url_parts.host, url_parts.path, ordered_query], "\n")
-      )
-      |> Base.encode64
-      |> URI.encode_www_form
-    signed_query = "#{url_parts.query}&Signature=#{signature}"
-    Map.put url_parts, :query, signed_query
+  defp encode(value) when is_bitstring(value) do
+    URI.encode(value, &URI.char_unreserved?/1)
+  end
+
+  defp encode(_) do
+    ""
   end
 end

--- a/lib/amazon_product_advertising_client/item_search.ex
+++ b/lib/amazon_product_advertising_client/item_search.ex
@@ -1,5 +1,5 @@
 defmodule AmazonProductAdvertisingClient.ItemSearch do
-  alias __MODULE__ 
+  alias __MODULE__
   alias AmazonProductAdvertisingClient.Config
 
   def __struct__ do
@@ -15,6 +15,7 @@ defmodule AmazonProductAdvertisingClient.ItemSearch do
       "SearchIndex"   => nil,
       "ResponseGroup" => nil,
       "Title"         => nil,
+      "Sort"          => nil,
     }
   end
 


### PR DESCRIPTION
Hi @zachgarwood! I'm very new to Elixir but I started a project where I needed to search the Amazon API and noticed that the signature wasn't valid for `Title`s containing a space. I wanted to write a failing test but I was unable to get the existing test to run due to some dependency issues. Anyway, this is what I came up with to make things work for me. I did remove the `process_url` callback and just computed the params up front. Feel free to merge or ignore. Either way, thanks for writing this!
