### PR TITLE
Default SearchIndex on ItemSearch to 'All'

### DIFF
--- a/lib/amazon_product_advertising_client/item_search.ex
+++ b/lib/amazon_product_advertising_client/item_search.ex
@@ -19,7 +19,8 @@ defmodule AmazonProductAdvertisingClient.ItemSearch do
       "ResponseGroup": nil,
       "SearchIndex": "All",
       "Sort": nil,
-      "Title": nil
+      "Title": nil,
+      "MerchantId": "Amazon"
 
   @doc """
   Execute an ItemSearch operation

--- a/lib/amazon_product_advertising_client/item_search.ex
+++ b/lib/amazon_product_advertising_client/item_search.ex
@@ -17,7 +17,7 @@ defmodule AmazonProductAdvertisingClient.ItemSearch do
       "MinimumPrice": nil,
       "Operation": "ItemSearch",
       "ResponseGroup": nil,
-      "SearchIndex": nil,
+      "SearchIndex": "All",
       "Sort": nil,
       "Title": nil
 


### PR DESCRIPTION
The README example for ItemSearch does not work because a `SearchIndex` is required by the Amazon API. While you can set this to some department value, it should default to just searching everything as that's the most common use case. Defaulting it to "All" makes sense to me.