### PR TITLE
Add MerchantId to ItemSearch struct and default it to Amazon

### DIFF
--- a/lib/amazon_product_advertising_client/item_search.ex
+++ b/lib/amazon_product_advertising_client/item_search.ex
@@ -19,7 +19,8 @@ defmodule AmazonProductAdvertisingClient.ItemSearch do
       "ResponseGroup": nil,
       "SearchIndex": "All",
       "Sort": nil,
-      "Title": nil
+      "Title": nil,
+      "MerchantId": "Amazon",
 
   @doc """
   Execute an ItemSearch operation


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AWSECommerceService/latest/DG/RG_Offers.html, when including "Offers" in the ResponseGroup, one can filter on the `MerchantId` which can have values of "Amazon" or "All". I think it's a safe assumption that most people would want to see the best Amazon offer instead of from 3rd party sellers (which doesn't include shipping price) so I think defaulting this to Amazon makes sense. 